### PR TITLE
Add report hours generator script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Report Hours Generator
+
+This repo contains a small script that creates a `Report` folder and calculates how many hours you have worked based on task descriptions.
+
+## How it works
+- Each task line can include time markers like `2h`, `1.5 hours`, or `30m`.
+- The script totals all the time markers found across the task file.
+- A `Report/summary.md` file is generated with per-task hours and the total.
+
+## Usage
+```bash
+python3 report_hours.py tasks.txt
+```
+
+You can also change the output directory:
+```bash
+python3 report_hours.py tasks.txt --report-dir Report
+```
+
+## Example task file
+See `tasks.txt` for a starter format.

--- a/report_hours.py
+++ b/report_hours.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Create a Report folder and total hours from task descriptions."""
+from __future__ import annotations
+
+import argparse
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+HOUR_PATTERN = re.compile(
+    r"(?P<value>\d+(?:\.\d+)?)\s*(?P<unit>h|hr|hrs|hour|hours|m|min|mins|minute|minutes)\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class TaskHours:
+    description: str
+    hours: float
+
+
+def parse_hours(line: str) -> float:
+    total = 0.0
+    for match in HOUR_PATTERN.finditer(line):
+        value = float(match.group("value"))
+        unit = match.group("unit").lower()
+        if unit.startswith("m"):
+            total += value / 60.0
+        else:
+            total += value
+    return total
+
+
+def load_tasks(lines: Iterable[str]) -> list[TaskHours]:
+    tasks = []
+    for raw in lines:
+        line = raw.strip()
+        if not line:
+            continue
+        hours = parse_hours(line)
+        tasks.append(TaskHours(description=line, hours=hours))
+    return tasks
+
+
+def write_report(report_dir: Path, tasks: list[TaskHours]) -> Path:
+    report_dir.mkdir(parents=True, exist_ok=True)
+    report_path = report_dir / "summary.md"
+    total_hours = sum(task.hours for task in tasks)
+    with report_path.open("w", encoding="utf-8") as handle:
+        handle.write("# Work Report\n\n")
+        handle.write("## Task Summary\n\n")
+        if tasks:
+            for task in tasks:
+                handle.write(f"- {task.description} → {task.hours:.2f} hours\n")
+        else:
+            handle.write("- No tasks provided.\n")
+        handle.write("\n")
+        handle.write(f"**Total Hours:** {total_hours:.2f}\n")
+    return report_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Create a Report folder and calculate total hours from task descriptions."
+    )
+    parser.add_argument(
+        "task_file",
+        nargs="?",
+        default="tasks.txt",
+        help="Path to a text file with task descriptions and time markers.",
+    )
+    parser.add_argument(
+        "--report-dir",
+        default="Report",
+        help="Directory name for the generated report.",
+    )
+    args = parser.parse_args()
+
+    task_path = Path(args.task_file)
+    if task_path.exists():
+        lines = task_path.read_text(encoding="utf-8").splitlines()
+    else:
+        lines = []
+
+    tasks = load_tasks(lines)
+    report_path = write_report(Path(args.report_dir), tasks)
+
+    total_hours = sum(task.hours for task in tasks)
+    print(f"Report saved to: {report_path}")
+    print(f"Total hours: {total_hours:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks.txt
+++ b/tasks.txt
@@ -1,0 +1,4 @@
+Drafted project outline (2h)
+Implemented API endpoints (3.5 hours)
+Design review meeting (45m)
+Bug fixes and code review (1h 30m)


### PR DESCRIPTION
### Motivation
- Provide a small CLI tool to create a `Report` folder and compute total worked hours from plain-text task descriptions. 
- Support common time markers (hours and minutes) so users can author tasks with `h`, `hours`, or `m` units. 
- Include documentation and a sample `tasks.txt` to make usage straightforward.

### Description
- Add `report_hours.py`, a Python CLI that parses time markers using a regex, converts minutes to fractional hours, and produces `Report/summary.md` with per-task hours and a total. 
- Add `README.md` documenting usage examples for `python3 report_hours.py tasks.txt` and the `--report-dir` option. 
- Add a sample `tasks.txt` demonstrating formats like `2h`, `3.5 hours`, `45m`, and `1h 30m`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982dd6850f4832e92089904b8e5a8e1)